### PR TITLE
Add Telegram notification support

### DIFF
--- a/.github/workflows/run_bot.yml
+++ b/.github/workflows/run_bot.yml
@@ -23,5 +23,7 @@ jobs:
         env:
           EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
           EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           python bot.py

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ It now processes **EUR/USD**, **XAU/USD (Gold)**, **AMZN (Amazon)**, and **NFLX 
 a notification email is sent to the configured recipients.
 
 Set the `EMAIL_FROM` and `EMAIL_PASSWORD` environment variables for sending email.
+To receive Telegram alerts, also configure `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID`.

--- a/bot.py
+++ b/bot.py
@@ -8,6 +8,8 @@ API_KEY = "313c54ea08cf4aedabff6cb615c6c6b4"
 EMAILS_TO = ["v.samimi@yahoo.com", "apminaei@gmail.com"]
 EMAIL_FROM = os.environ.get("EMAIL_FROM")
 EMAIL_PASSWORD = os.environ.get("EMAIL_PASSWORD")
+TELEGRAM_TOKEN = os.environ.get("TELEGRAM_TOKEN")
+TELEGRAM_CHAT_ID = os.environ.get("TELEGRAM_CHAT_ID")
 
 def get_data(symbol: str):
     print(f"📥 Fetching data for {symbol} from Twelve Data...")
@@ -68,6 +70,22 @@ def send_email(subject, body):
             server.send_message(msg)
     print("✅ Email sent successfully.")
 
+def send_telegram(text: str):
+    print("📲 Sending Telegram notification...")
+    if not TELEGRAM_TOKEN or not TELEGRAM_CHAT_ID:
+        print("⚠️ Telegram credentials not configured.")
+        return
+    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
+    payload = {"chat_id": TELEGRAM_CHAT_ID, "text": text}
+    try:
+        resp = requests.post(url, data=payload)
+        if resp.status_code != 200:
+            print(f"❌ Telegram error: {resp.text}")
+        else:
+            print("✅ Telegram message sent successfully.")
+    except Exception as e:
+        print(f"❌ Telegram exception: {e}")
+
 def process_symbol(symbol: str):
     df = get_data(symbol)
     if df is None:
@@ -75,9 +93,13 @@ def process_symbol(symbol: str):
         return
     buy, sell = check_strategy(df)
     if buy:
-        send_email(f"{symbol} Buy Signal", f"Buy signal detected on {symbol}!")
+        message = f"Buy signal detected on {symbol}!"
+        send_email(f"{symbol} Buy Signal", message)
+        send_telegram(message)
     elif sell:
-        send_email(f"{symbol} Sell Signal", f"Sell signal detected on {symbol}!")
+        message = f"Sell signal detected on {symbol}!"
+        send_email(f"{symbol} Sell Signal", message)
+        send_telegram(message)
     else:
         print(f"ℹ️ No signal detected for {symbol}.")
 


### PR DESCRIPTION
## Summary
- send Telegram notifications in addition to email
- document new environment variables
- expose Telegram secrets to the workflow

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68639ea39fdc832db248ca875269da93